### PR TITLE
🐛 Fix : firstName/lastName 필드 의미 수정 (이름/성 구분 정정)

### DIFF
--- a/src/main/java/com/example/gguro/converter/ProfileConverter.java
+++ b/src/main/java/com/example/gguro/converter/ProfileConverter.java
@@ -14,7 +14,7 @@ public class ProfileConverter {
     public static Profile addProfile(User user, ProfileRequestDTO.ProfileDTO request) {
         return Profile.builder()
                 .user(user)
-                .name(request.getFirstName()+request.getLastName())
+                .name(request.getLastName()+request.getFirstName())
                 .birth(String.format("%d-%02d-%02d", request.getYear(), request.getMonth(), request.getDay()))
                 .build();
     }

--- a/src/main/java/com/example/gguro/service/ProfileService/ProfileCommandServiceImpl.java
+++ b/src/main/java/com/example/gguro/service/ProfileService/ProfileCommandServiceImpl.java
@@ -57,7 +57,7 @@ public class ProfileCommandServiceImpl implements ProfileCommandService{
             throw new ProfileHandler(ErrorStatus.PROFILE_NOT_FOUND);
         }
 
-        profile.setName(request.getFirstName()+request.getLastName());
+        profile.setName(request.getLastName()+request.getFirstName());
         profile.setBirth(String.format("%d-%02d-%02d", request.getYear(), request.getMonth(), request.getDay()));
         profileRepository.save(profile);
 

--- a/src/main/java/com/example/gguro/web/dto/profile/ProfileRequestDTO.java
+++ b/src/main/java/com/example/gguro/web/dto/profile/ProfileRequestDTO.java
@@ -16,10 +16,10 @@ public class ProfileRequestDTO {
     @AllArgsConstructor
     @ValidDate
     public static class ProfileDTO{
-        @NotNull(message = "이름(성) 작성은 필수입니다.")
+        @NotNull(message = "이름 작성은 필수입니다.")
         private String firstName;
 
-        @NotNull(message = "이름 작성은 필수입니다.")
+        @NotNull(message = "이름(성) 작성은 필수입니다.")
         private String lastName;
 
         @NotNull(message = "생년월일(년도) 작성은 필수입니다.")


### PR DESCRIPTION
## 작업 내용

firstName/lastName 필드 의미 수정 (이름/성 구분 정정)

## 참고 사항

ㅎㅎ firstName을 성으로 생각하고 했어서 ㅎㅎㅎ 이 부분 수정했어욥

## 연관 이슈


<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 프로필 이름 표시 시, 이름과 성의 순서가 '성 + 이름'으로 변경되었습니다.
  * 프로필 등록 및 수정 시, 이름과 성 입력란의 유효성 검사 메시지가 올바르게 표시되도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->