### PR TITLE
✨ Feat - 프로필 이름만 반환하는 API 구현

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -51,10 +51,12 @@ jobs:
           echo "${{ secrets.EC2_SSH_KEY }}" > ec2-key.pem
           chmod 400 ec2-key.pem
 
-      - name: Copy .jar to EC2
+      # rsync로 전송 최적화 (압축 + 덮어쓰기)
+      - name: Copy .jar to EC2 (with rsync)
         run: |
-          scp -i ec2-key.pem -o StrictHostKeyChecking=no ./build/libs/gguro-1.0.0.jar \
-          ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }}:/home/ubuntu/gguro/gguro-1.0.0.jar
+          rsync -avz -e "ssh -i ec2-key.pem -o StrictHostKeyChecking=no" \
+          ./build/libs/gguro-1.0.0.jar \
+          ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }}:/home/ubuntu/gguro/
 
       - name: Update env file & restart service
         run: |

--- a/src/main/java/com/example/gguro/service/ProfileService/ProfileQueryService.java
+++ b/src/main/java/com/example/gguro/service/ProfileService/ProfileQueryService.java
@@ -10,4 +10,5 @@ public interface ProfileQueryService {
     ProfileResponseDTO.ProfileListViewDTO getProfileList(User user);
     String getProfileFirstNamePossessiveMarker(User user, Long profileId);
     String getProfileFirstNameNominativeCaseMarker(User user, Long profileId);
+    String getProfileFirstName(User user, Long profileId);
 }

--- a/src/main/java/com/example/gguro/service/ProfileService/ProfileQueryServiceImpl.java
+++ b/src/main/java/com/example/gguro/service/ProfileService/ProfileQueryServiceImpl.java
@@ -69,6 +69,19 @@ public class ProfileQueryServiceImpl  implements ProfileQueryService {
         return getVocativeNameNominativeCaseMarker(profile.getFirstName());
     }
 
+    @Override
+    public String getProfileFirstName(User user, Long profileId) {
+        Profile profile = profileRepository.findById(profileId)
+                .orElseThrow(() -> new ProfileHandler(ErrorStatus.PROFILE_NOT_FOUND));
+
+        // 해당 프로필이 이 유저의 프로필이 맞는지
+        if(!profile.getUser().equals(user)) {
+            throw new ProfileHandler(ErrorStatus.PROFILE_NOT_FOUND);
+        }
+
+        return profile.getFirstName();
+    }
+
     // 소유격 조사
     private String getVocativeNamePossessiveMarker(String name) {
         if (name == null || name.isEmpty()) return "";

--- a/src/main/java/com/example/gguro/web/controller/ProfileController.java
+++ b/src/main/java/com/example/gguro/web/controller/ProfileController.java
@@ -89,4 +89,14 @@ public class ProfileController {
         User user = getCurrentUser();
         return ApiResponse.onSuccess(profileQueryService.getProfileFirstNameNominativeCaseMarker(user, profileId));
     }
+
+    @GetMapping("/api/profile/first-name/{profileId}")
+    @Operation(summary = "해당 프로필의 이름을 반환", description = "해당 프로필의 이름을 조회할 수 있습니다.")
+    public ApiResponse<String> getProfileFirstName(
+            @PathVariable Long profileId
+    ) {
+        User user = getCurrentUser();
+        return ApiResponse.onSuccess(profileQueryService.getProfileFirstName(user, profileId));
+    }
+
 }


### PR DESCRIPTION
## 작업 내용

✨ Feat - 프로필 이름만 반환하는 API 구현
## 참고 사항

> 코드 리뷰 시 참고할 만한 사항이나 주의할 점을 작성해주세요.

## 연관 이슈

> 이 PR과 연관된 이슈 번호를 작성하세요. 예) close #56 


<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 프로필의 순수 ‘이름(First name)’을 반환하는 읽기 전용 API 추가: GET /api/profile/first-name/{profileId}. 기존 이름의 격/조사 변형 조회와 별도로 기본 형태를 직접 조회할 수 있습니다.
* 문서
  * OpenAPI 문서에 신규 엔드포인트의 요약과 설명을 추가하여 API 탐색 및 자동 생성 클라이언트에서 즉시 확인 가능합니다.
* 잡무(Chores)
  * 배포 워크플로우에서 파일 전송 방식을 SCP에서 rsync로 변경하여 배포 효율성 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->