### PR TITLE
♻️ Refactor : 애플 로그인 시, 스웨거에 application/x-www-form-urlencoded 폼으로 뜨도…

### DIFF
--- a/src/main/java/com/example/gguro/web/controller/AuthController.java
+++ b/src/main/java/com/example/gguro/web/controller/AuthController.java
@@ -8,11 +8,12 @@ import com.example.gguro.service.OAuthService.NaverLoginCommandService;
 import com.example.gguro.service.UserService.UserCommandService;
 import com.example.gguro.web.dto.UserRequestDTO;
 import com.example.gguro.web.dto.UserResponseDTO;
+import com.example.gguro.web.dto.apple.AppleCodeForm;
 import com.example.gguro.web.dto.kakao.KakaoLoginRequestDTO;
 import com.example.gguro.web.dto.naver.NaverLoginRequestDTO;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import org.springframework.util.MultiValueMap;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -80,15 +81,19 @@ public class AuthController {
     @Operation(
             summary = "애플 로그인",
             description = "Apple 로그인 API",
-            parameters = {
-                    @Parameter(name = "code", in = ParameterIn.QUERY, description = "Apple에서 받은 인증 코드", required = true,
-                            content = @Content(mediaType = "application/x-www-form-urlencoded", schema = @Schema(type = "string")))
-            }
+            requestBody = @RequestBody(
+                    required = true,
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_FORM_URLENCODED_VALUE,
+                            schema = @Schema(implementation = AppleCodeForm.class)
+                    )
+            )
     )
     @PostMapping(value = "/api/auth/apple", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
     public ApiResponse<UserResponseDTO.UserLoginResponseDTO> appleLogin(
-            @RequestParam("code") String code
+            @org.springframework.web.bind.annotation.RequestBody MultiValueMap<String, String> form
     ) {
+        String code = form.getFirst("code");
         log.info("Received from Apple: code = {}", code);
         return ApiResponse.onSuccess(appleLoginCommandService.appleLogin(code));
     }

--- a/src/main/java/com/example/gguro/web/dto/apple/AppleCodeForm.java
+++ b/src/main/java/com/example/gguro/web/dto/apple/AppleCodeForm.java
@@ -1,0 +1,12 @@
+package com.example.gguro.web.dto.apple;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class AppleCodeForm {
+    @Schema(description = "Apple에서 받은 인증 코드", requiredMode = Schema.RequiredMode.REQUIRED,
+            example = "cd6f93025f866449b99200f06e1f3add3.0.pxsy.yx-QnoXE42wi-3FVb2Lacw")
+    private String code;
+}


### PR DESCRIPTION
…록 수정

## 작업 내용

> 해당 PR에서 작업한 내용을 간결하게 정리해주세요.

## 참고 사항

> 코드 리뷰 시 참고할 만한 사항이나 주의할 점을 작성해주세요.

## 연관 이슈




<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Apple 로그인 API가 쿼리 파라미터 대신 application/x-www-form-urlencoded 본문으로 인증 코드를 수신하도록 변경되었습니다. 클라이언트는 code 필드로 전송해야 합니다. 응답 형태와 동작은 동일합니다.
- Documentation
  - OpenAPI 문서를 갱신하여 요청 본문 스키마와 예시를 추가했습니다. API 사용 방법이 본문 기반으로 반영되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->